### PR TITLE
Merge in image

### DIFF
--- a/fias/menuroi_an.py
+++ b/fias/menuroi_an.py
@@ -169,6 +169,14 @@ class ROIimage():
 			self._inputdata['fiber_number'][ind_curr] = fn_min
 
 		ROIdata.fiber_new_number(self)
+		ROIdisplay.noshow_roi(self)
+
+		del self._roipath; del self._roilabel
+
+		if self._menucheckRM.get() == 1:
+			self._roiListbox.delete(0, 'end')
+
+		MainDisplay.show_overlay(self)
 
 
 	def data_roi(self, id_roi):

--- a/fias/menuroi_an.py
+++ b/fias/menuroi_an.py
@@ -21,9 +21,9 @@ class ROIdraw():
 		self._cpressed = 0
 
 		if self._menucheckRI.get() == 0:
-			canvas = self._canvas;
+			canvas = self._canvas
 			ROIimage.init_var(self)
-		elif self._menucheckRI.get() == 2: canvas = self._canvas;
+		elif self._menucheckRI.get() == 2: canvas = self._canvas
 
 		if self._menucheckRD.get() == 1: ROIdraw.connect_mpl(self, canvas)
 		elif self._menucheckRD.get() == 0: ROIdraw.disconnect_mpl(self, canvas)
@@ -152,6 +152,25 @@ class ROIimage():
 
 		MainDisplay.show_overlay(self)
 
+	def mergeall(self):
+
+		ROIdraw.reset(self)
+
+		ind_sel = []
+
+		for item in np.arange(len(self._roipath)):
+			ind_sel.extend(ROIimage.data_roi(self, self._roipath[item]))
+
+		fiber_selec = np.unique(self._inputdata['fiber_number'][ind_sel])
+		fn_min = np.min(fiber_selec)
+		
+		for ifiber in fiber_selec:
+			ind_curr = np.where(self._inputdata['fiber_number']==ifiber)[0]
+			self._inputdata['fiber_number'][ind_curr] = fn_min
+
+		ROIdata.fiber_new_number(self)
+
+
 	def data_roi(self, id_roi):
 
 		ind_all = np.arange(len(self._inputdata['fiber_number']))
@@ -224,18 +243,7 @@ class ROIimage():
 			else: fn_min = np.min(self._inputdata['fiber_number'].flatten())
 			self._inputdata['fiber_number'][selec_data_indices] = fn_min - 1
 		
-		try: 
-			ind_fib = np.where(self._inputdata['fiber_number'] >=0)[0]
-			ind_fib[0]
-			nc = -1
-			fiber_number = 1*self._inputdata['fiber_number']	
-			for ich in np.unique(self._inputdata['fiber_number'][ind_fib]):
-				nc = nc + 1
-				selec_data_indices = np.where(self._inputdata['fiber_number'] == ich)[0]
-				fiber_number[selec_data_indices] = nc
-			self._inputdata['fiber_number'] = fiber_number
-		except IndexError: pass
-			
+		ROIdata.fiber_new_number(self)
 
 class ROIdata():
 
@@ -262,6 +270,19 @@ class ROIdata():
 													indices, axis = 0)
 		self._inputdata['fiber_y2'] = np.delete(self._inputdata['fiber_y2'],
 													indices, axis = 0)
+
+	def fiber_new_number(self):
+		try: 
+			ind_fib = np.where(self._inputdata['fiber_number'] >=0)[0]
+			ind_fib[0]
+			nc = -1
+			fiber_number = 1*self._inputdata['fiber_number']	
+			for ich in np.unique(self._inputdata['fiber_number'][ind_fib]):
+				nc = nc + 1
+				selec_data_indices = np.where(self._inputdata['fiber_number'] == ich)[0]
+				fiber_number[selec_data_indices] = nc
+			self._inputdata['fiber_number'] = fiber_number
+		except IndexError: pass
 
 	def get_incircle(self, roi_circle, xp, yp):
 

--- a/fias/winan.py
+++ b/fias/winan.py
@@ -79,7 +79,7 @@ class WindowAnalysis():
 		print('s')
 
 	def roi_mergeall(self, event):
-		print('m')
+		ROIimage.mergeall(self)
 		
 	def ref_set(self, event):
 		if self._menucheckMS.get() == 0: self._menucheckMS.set(1)
@@ -249,7 +249,8 @@ class MenuAnalysis():
 								accelerator = 'Shift+s')
 		self.menuroi.add_command(label = 'Merge',
 								underline = 0,
-								accelerator = 'Shift+m')
+								accelerator = 'Shift+m',
+								command = lambda: ROIimage.mergeall(self))
 		self.menuroi.add_separator()
 		self.menuroi.add_checkbutton(label = 'Show ROI Manager',
 									variable = self._menucheckRM)


### PR DESCRIPTION
Added option to merge filaments that have been identified as different, so they get the same ID number. It works using the circle and rectangle ROIs drawn on the image. 

ID numbers **DO NOT** get updated for filaments identified as references.